### PR TITLE
Empty collection in `errors` field

### DIFF
--- a/CommandPattern.md
+++ b/CommandPattern.md
@@ -79,7 +79,7 @@ Sample response:
     },
     "output" : {
         "status" : "VALIDATED_AND_RUNNING",
-        "errors" : null,
+        "errors" : [],
         "newOffer" : null
     }
 }
@@ -108,7 +108,7 @@ Response:
     },
     "output" : {
         "status" : "SUCCESSFUL",
-        "errors" : null,
+        "errors" : [],
         "newOffer" : {
             "id" : "607445543"
         }


### PR DESCRIPTION
If errors are empty an empty collection should be returned instead of a null